### PR TITLE
clean trash file after test process interrupted

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -27,6 +27,7 @@ clean: clean-test-results
 clean-test-results:
 	@echo "*** $@ ***"
 	-rm -rf test-results
+	-rm -rf 'trash directory'.*.sh
 
 $(T): clean-test-results deps
 	@echo "*** $@ ***"


### PR DESCRIPTION
If test process failed or interrupted, `trash directory.*.sh/`
directory still remained, and can't cleaned by 'make clean'.

Add "rm -rf 'trash directory'.*.sh" in Makefile can fix this issue.

Fix  #4 

cc @chriscool 